### PR TITLE
Moving from RestClient to Faraday

### DIFF
--- a/lib/on_the_dot_api.rb
+++ b/lib/on_the_dot_api.rb
@@ -1,4 +1,4 @@
-require 'rest-client'
+require 'faraday'
 
 require 'on_the_dot_api/version'
 require 'on_the_dot_api/config'

--- a/lib/on_the_dot_api/version.rb
+++ b/lib/on_the_dot_api/version.rb
@@ -1,3 +1,3 @@
 module OnTheDotApi
-  VERSION = '0.7.1'
+  VERSION = '0.8.0'
 end

--- a/on_the_dot_api.gemspec
+++ b/on_the_dot_api.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency 'rest-client', '~> 2.0.1'
+  s.add_dependency 'faraday', '~> 0.9.2'
 
   s.add_development_dependency 'dotenv-rails', '2.0.2'
   s.add_development_dependency 'pry'

--- a/spec/errors/response_error_spec.rb
+++ b/spec/errors/response_error_spec.rb
@@ -5,7 +5,7 @@ describe OnTheDotApi::Errors::ResponseError do
   let(:payload) { "payload example" }
   let(:http_body) { "Bad Request"}
   let(:response) { "Bad Request" }
-  let(:message) { "400 Bad Request"}
+  let(:message) { "400"}
 
   subject do
     described_class.new(

--- a/spec/operations/cancel_booking_spec.rb
+++ b/spec/operations/cancel_booking_spec.rb
@@ -52,7 +52,7 @@ describe OnTheDotApi::Operations::CancelBooking do
         VCR.use_cassette('cancel_booking_request_with_random_order_number') do
           expect {
             described_class.new(order_number: "nil").execute
-          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "404 Not Found")
+          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "404")
         end
       end
     end

--- a/spec/operations/create_booking_spec.rb
+++ b/spec/operations/create_booking_spec.rb
@@ -63,7 +63,7 @@ describe OnTheDotApi::Operations::CreateBooking do
               payload: invalid_payload,
               headers: headers
             ).execute
-          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "400 Bad Request")
+          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "400")
         end
       end
     end
@@ -83,7 +83,7 @@ describe OnTheDotApi::Operations::CreateBooking do
               payload: invalid_payload,
               headers: headers
             ).execute
-          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "404 Not Found")
+          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "404")
         end
       end
     end
@@ -96,7 +96,7 @@ describe OnTheDotApi::Operations::CreateBooking do
               payload: valid_payload,
               headers: { "UUID": "1111" }
             ).execute
-          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "400 Bad Request")
+          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "400")
         end
       end
     end

--- a/spec/operations/get_all_bookings_spec.rb
+++ b/spec/operations/get_all_bookings_spec.rb
@@ -11,7 +11,7 @@ describe OnTheDotApi::Operations::GettAllBookings do
     it "gets all the bookings" do
       VCR.use_cassette('valid_get_all_bookings_request') do
         response_hash = described_class.new(
-          headers: { params: { "pageNumber": 1, "pageSize": 25 }}
+          params: { "pageNumber": 1, "pageSize": 25 }
         ).execute
 
         expect(response_hash["success"]).to eq({"status"=>"ok"})

--- a/spec/operations/get_available_timeslots_spec.rb
+++ b/spec/operations/get_available_timeslots_spec.rb
@@ -34,7 +34,7 @@ describe OnTheDotApi::Operations::GetAvailableTimeslots do
         VCR.use_cassette('invalid_get_available_timeslots_request') do
           expect {
             described_class.new(payload: invalid_payload).execute
-          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "400 Bad Request")
+          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "400")
         end
       end
     end

--- a/spec/operations/retrieve_booking_spec.rb
+++ b/spec/operations/retrieve_booking_spec.rb
@@ -53,7 +53,7 @@ describe OnTheDotApi::Operations::RetrieveBooking do
         VCR.use_cassette('retrieve_booking_request_with_invalid_order_number') do
           expect {
             described_class.new(order_number: "abc").execute
-          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "400 Bad Request")
+          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "400")
         end
       end
     end

--- a/spec/operations/track_delivery_spec.rb
+++ b/spec/operations/track_delivery_spec.rb
@@ -52,7 +52,7 @@ describe OnTheDotApi::Operations::TrackDelivery do
         VCR.use_cassette('track_delivery_request_with_random_order_number') do
           expect {
             described_class.new(order_number: "abc").execute
-          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "401 Unauthorized")
+          }.to raise_exception(OnTheDotApi::Errors::ResponseError, "401")
         end
       end
     end

--- a/spec/support/fixtures/vcr_cassettes/track_delivery_request_with_random_order_number.yml
+++ b/spec/support/fixtures/vcr_cassettes/track_delivery_request_with_random_order_number.yml
@@ -7,37 +7,35 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (darwin17.4.0 x86_64) ruby/2.4.3p205
       Channel:
       - ECOM
       # Authorization:
       # - Bearer {removed API key}
       Content-Type:
       - application/json
-      Host:
-      - sbapi.onthedot.com
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 401
       message: Unauthorized
     headers:
       Accept-Encoding:
-      - gzip, deflate
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Activityid:
-      - '1203087168428255079286028'
+      - '1210232109966119986787977'
       Assertion:
-      - eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0=.eyJpc3MiOiJ3c28yLm9yZy9wcm9kdWN0cy9hbSIsImV4cCI6MTUyMzk3MjMzMzE4MCwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9zdWJzY3JpYmVyIjoic3RldmVAYmxvb21hbmR3aWxkLmNvbSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25pZCI6IjE4OSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25uYW1lIjoiQmxvb21hbmRXaWxkIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9hcHBsaWNhdGlvbnRpZXIiOiJVbmxpbWl0ZWQiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2FwaWNvbnRleHQiOiIvYXBpIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy92ZXJzaW9uIjoidjEuMCIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvdGllciI6IlVubGltaXRlZCIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMva2V5dHlwZSI6IlBST0RVQ1RJT04iLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3VzZXJ0eXBlIjoiQVBQTElDQVRJT04iLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2VuZHVzZXIiOiJzdGV2ZUBibG9vbWFuZHdpbGQuY29tIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9lbmR1c2VyVGVuYW50SWQiOiItMTIzNCIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2NvdW50cnkiOiJVSyIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2VtYWlsYWRkcmVzcyI6InN0ZXZlQGJsb29tYW5kd2lsZC5jb20iLCAiaHR0cDovL3dzbzIub3JnL2NsYWltcy9naXZlbm5hbWUiOiJTdGV2ZSIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2xhc3RuYW1lIjoiSmFuYXdheSIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3JvbGUiOiJJbnRlcm5hbC9zdWJzY3JpYmVyLEludGVybmFsL2V2ZXJ5b25lLEludGVybmFsL2lkZW50aXR5IiwgImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvdW5pcXVlSWQiOiIyMDUzNiJ9.
+      - eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0=.eyJpc3MiOiJ3c28yLm9yZy9wcm9kdWN0cy9hbSIsImV4cCI6MTUyNDA0NDY1NDgzOCwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9zdWJzY3JpYmVyIjoic3RldmVAYmxvb21hbmR3aWxkLmNvbSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25pZCI6IjE4OSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25uYW1lIjoiQmxvb21hbmRXaWxkIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9hcHBsaWNhdGlvbnRpZXIiOiJVbmxpbWl0ZWQiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2FwaWNvbnRleHQiOiIvYXBpIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy92ZXJzaW9uIjoidjEuMCIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvdGllciI6IlVubGltaXRlZCIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMva2V5dHlwZSI6IlBST0RVQ1RJT04iLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3VzZXJ0eXBlIjoiQVBQTElDQVRJT04iLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2VuZHVzZXIiOiJzdGV2ZUBibG9vbWFuZHdpbGQuY29tIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9lbmR1c2VyVGVuYW50SWQiOiItMTIzNCIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2NvdW50cnkiOiJVSyIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2VtYWlsYWRkcmVzcyI6InN0ZXZlQGJsb29tYW5kd2lsZC5jb20iLCAiaHR0cDovL3dzbzIub3JnL2NsYWltcy9naXZlbm5hbWUiOiJTdGV2ZSIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2xhc3RuYW1lIjoiSmFuYXdheSIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3JvbGUiOiJJbnRlcm5hbC9zdWJzY3JpYmVyLEludGVybmFsL2V2ZXJ5b25lLEludGVybmFsL2lkZW50aXR5IiwgImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvdW5pcXVlSWQiOiIyMDUzNiJ9.
       Channel:
       - ECOM
       Content-Type:
       - application/json
       Date:
-      - Tue, 17 Apr 2018 13:39:07 GMT
+      - Wed, 18 Apr 2018 09:29:50 GMT
       Server:
       - PassThrough-HTTP
       X-Forwarded-For:
@@ -63,5 +61,5 @@ http_interactions:
             ]
         }
     http_version:
-  recorded_at: Tue, 17 Apr 2018 13:39:07 GMT
+  recorded_at: Wed, 18 Apr 2018 09:29:51 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/helpers/client_helper.rb
+++ b/spec/support/helpers/client_helper.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 def configure_client
   OnTheDotApi::Client.configure do |config|
     logger = Logger.new(STDERR)


### PR DESCRIPTION
We had problems with RestClient logging. They don't support logging we need in the current version and it is not clear when it will be supported. 