### PR TITLE
[#160686434] new url format

### DIFF
--- a/lib/on_the_dot_api/operations/amend_booking.rb
+++ b/lib/on_the_dot_api/operations/amend_booking.rb
@@ -6,7 +6,7 @@ module OnTheDotApi
       end
 
       def endpoint
-        "#{base_url}/v1.0/amendbooking/"
+        "#{base_url}/v1.0/amendbooking"
       end
     end
   end

--- a/lib/on_the_dot_api/operations/cancel_booking.rb
+++ b/lib/on_the_dot_api/operations/cancel_booking.rb
@@ -6,7 +6,7 @@ module OnTheDotApi
       end
 
       def endpoint
-        "#{base_url}/v1.0/cancelbooking/#{store_id}/#{options[:order_number]}/"
+        "#{base_url}/v1.0/cancelbooking/#{store_id}/#{options[:order_number]}"
       end
     end
   end

--- a/lib/on_the_dot_api/operations/create_booking.rb
+++ b/lib/on_the_dot_api/operations/create_booking.rb
@@ -6,7 +6,7 @@ module OnTheDotApi
       end
 
       def endpoint
-        "#{base_url}/v1.0/booking/"
+        "#{base_url}/v1.0/booking"
       end
     end
   end

--- a/lib/on_the_dot_api/operations/get_all_bookings.rb
+++ b/lib/on_the_dot_api/operations/get_all_bookings.rb
@@ -6,7 +6,7 @@ module OnTheDotApi
       end
 
       def endpoint
-        "#{base_url}/v1.0/bookings/storeid/#{store_id}/"
+        "#{base_url}/v1.0/bookings/storeid/#{store_id}"
       end
     end
   end

--- a/lib/on_the_dot_api/operations/get_available_timeslots.rb
+++ b/lib/on_the_dot_api/operations/get_available_timeslots.rb
@@ -6,7 +6,7 @@ module OnTheDotApi
       end
 
       def endpoint
-        "#{base_url}/v1.0/timeslotsV2/"
+        "#{base_url}/v1.0/timeslotsV2"
       end
     end
   end

--- a/lib/on_the_dot_api/operations/retrieve_booking.rb
+++ b/lib/on_the_dot_api/operations/retrieve_booking.rb
@@ -6,7 +6,7 @@ module OnTheDotApi
       end
 
       def endpoint
-        "#{base_url}/v1.0/bookings/orderid/#{store_id}/#{options[:order_number]}/"
+        "#{base_url}/v1.0/bookings/orderid/#{store_id}/#{options[:order_number]}"
       end
     end
   end

--- a/lib/on_the_dot_api/operations/track_delivery.rb
+++ b/lib/on_the_dot_api/operations/track_delivery.rb
@@ -6,7 +6,7 @@ module OnTheDotApi
       end
 
       def endpoint
-        "#{base_url}/v1.0/track/store/#{store_id}/job/#{options[:order_number]}/"
+        "#{base_url}/v1.0/track/store/#{store_id}/job/#{options[:order_number]}"
       end
     end
   end


### PR DESCRIPTION
Sandbox environment stopped working with the old format (`/` in the end of the url). This is a small update to fix it. It works for both sandbox and production environments.   